### PR TITLE
31 category edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-i18next": "^13.5.0",
     "react-toastify": "^9.1.3",
     "server-only": "^0.0.1",
+    "tailwind-merge": "^2.2.1",
     "yup": "^1.3.2",
     "zustand": "^4.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ dependencies:
   server-only:
     specifier: ^0.0.1
     version: 0.0.1
+  tailwind-merge:
+    specifier: ^2.2.1
+    version: 2.2.1
   yup:
     specifier: ^1.3.2
     version: 1.3.3
@@ -5121,6 +5124,12 @@ packages:
       csso: 5.0.5
       picocolors: 1.0.0
     dev: true
+
+  /tailwind-merge@2.2.1:
+    resolution: {integrity: sha512-o+2GTLkthfa5YUt4JxPfzMIpQzZ3adD1vLVkvKE1Twl9UAhGsEbIZhHHZVRttyW177S8PDJI3bTQNaebyofK3Q==}
+    dependencies:
+      '@babel/runtime': 7.23.8
+    dev: false
 
   /tailwindcss@3.4.1:
     resolution: {integrity: sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==}

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -21,7 +21,7 @@ const Button = ({ children, variant, ...props }: ButtonProps) => {
       }
       case 'outlined': {
         className =
-          'box-border bg-white text-black dark:bg-primary dark:text-white dark:disabled:bg-primary/70 disabled:bg-white/70';
+          'box-border border border-primary text-black  dark:text-white disabled:bg-transparent/5';
         break;
       }
     }

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode;
@@ -7,12 +8,33 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const Button = ({ children, variant, ...props }: ButtonProps) => {
+  const variantClass = () => {
+    let className = '';
+    switch (variant) {
+      case 'text': {
+        className = 'text-black dark:text-white';
+        break;
+      }
+      case 'contained': {
+        className = 'box-border bg-primary disabled:bg-primary/70';
+        break;
+      }
+      case 'outlined': {
+        className =
+          'box-border bg-white text-black dark:bg-primary dark:text-white dark:disabled:bg-primary/70 disabled:bg-white/70';
+        break;
+      }
+    }
+    return className;
+  };
+
   return (
     <button
       {...props}
-      className={`${props.className ? `${props.className} ` : ''} ${
-        variant ? `btn-${variant}` : ''
-      }`}
+      className={twMerge(
+        `h-12 rounded-[4px] px-4 py-1 ${props.disabled && 'bg cursor-not-allowed'} ${variantClass()} `,
+        `${props.className}`,
+      )}
       type={props.type ? props.type : 'button'}
     >
       {children}

--- a/src/components/atoms/dialog/Dialog.tsx
+++ b/src/components/atoms/dialog/Dialog.tsx
@@ -17,6 +17,7 @@ type DialogProps = {
   };
   backdrop?: boolean;
   className?: string;
+  TitleComonent?: React.JSX.Element;
 };
 
 const Dialog = ({
@@ -27,6 +28,7 @@ const Dialog = ({
   closeBtn,
   backdrop = true,
   className = '',
+  TitleComonent,
 }: DialogProps) => {
   const closeModal = () => {
     close();
@@ -76,6 +78,8 @@ const Dialog = ({
                     {title.label}
                   </Modal.Title>
                 )}
+                {TitleComonent && <Modal.Title as="h3">{TitleComonent}</Modal.Title>}
+
                 <div>{children}</div>
                 {closeBtn && (
                   <div className="mt-4">

--- a/src/components/molecules/categoryIcon/CategoryIcon.hook.tsx
+++ b/src/components/molecules/categoryIcon/CategoryIcon.hook.tsx
@@ -1,0 +1,35 @@
+import { deleteCategory } from '@/services/category';
+import { useMutation } from '@tanstack/react-query';
+import React, { useState } from 'react';
+
+const useCategoryIcon = (selectedCategoryId: string) => {
+  // 닫기 모달
+  const [isShowCloseModal, setIsShowCloseModal] = useState(false);
+  const handleCloseModal = () => {
+    setIsShowCloseModal(false);
+  };
+  const handleShowDeleteConfirmDialog = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsShowCloseModal(true);
+  };
+  const mutation = useMutation({
+    mutationFn: deleteCategory,
+    onSuccess: () => {
+      handleCloseModal();
+    },
+  });
+  const handleDeleteCategory = () => {
+    mutation.mutate(selectedCategoryId);
+  };
+
+  return {
+    isShowCloseModal,
+    setIsShowCloseModal,
+    handleCloseModal,
+    handleShowDeleteConfirmDialog,
+    handleDeleteCategory,
+  };
+};
+
+export default useCategoryIcon;

--- a/src/components/molecules/categoryIcon/CategoryIcon.tsx
+++ b/src/components/molecules/categoryIcon/CategoryIcon.tsx
@@ -2,6 +2,8 @@ import { Category } from '@/types/task/task.type';
 import Image from 'next/image';
 import React from 'react';
 import CancleIcon from '@/images/icons/cancle.svg';
+import useCategoryIcon from './CategoryIcon.hook';
+import DeleteConfirmDialog from '@/components/organisms/taskDetail/DeleteConfirmDialog';
 
 type CategoryIconProps = {
   category: Category;
@@ -15,24 +17,57 @@ const CategoryIcon = ({
   selectedCategoryId,
   isEditMode,
 }: CategoryIconProps) => {
+  const {
+    isShowCloseModal,
+    handleCloseModal,
+    handleShowDeleteConfirmDialog,
+    handleDeleteCategory,
+  } = useCategoryIcon(selectedCategoryId);
   return (
-    <button type="button" onClick={() => handleClickCategory(category)}>
-      <div
-        className={`relative mx-auto h-16 w-16 basis-1/4 rounded-md ${category.color} 
-          ${category._id === selectedCategoryId ? 'border-[3px] border-primary' : ''}
-          ${isEditMode ? ' border-[3px] border-dashed border-primary' : ''}
+    <>
+      <button type="button" onClick={() => handleClickCategory(category)}>
+        <div
+          className={`relative mx-auto h-16 w-16 basis-1/4 rounded-md ${category.color} 
+          ${category._id === selectedCategoryId && 'border-[3px] border-primary'}
+          ${isEditMode && ' border-[3px] border-dashed border-primary'}
         `}
-      >
-        {isEditMode && <CancleIcon className="absolute right-[-7px] top-[-7px]" />}
+        >
+          {/* deleteBtn */}
+          {isEditMode && (
+            <div
+              onClick={handleShowDeleteConfirmDialog}
+              className="absolute right-[-7px] top-[-7px]"
+            >
+              <CancleIcon className="cursor-pointer" />
+            </div>
+          )}
 
-        <div className="flex h-full items-center justify-center p-1.5">
-          <div className="flex-none">
-            <Image src={category.icon} alt="icon" width={42} height={42} />
+          <div className="flex h-full items-center justify-center p-1.5">
+            <div className="flex-none">
+              <Image src={category.icon} alt="icon" width={42} height={42} />
+            </div>
           </div>
         </div>
-      </div>
-      <div className="mt-2 truncate text-sm">{category.name}</div>
-    </button>
+        <div className="mt-2 truncate text-sm">{category.name}</div>
+      </button>
+
+      <DeleteConfirmDialog
+        isShowModal={isShowCloseModal}
+        close={handleCloseModal}
+        dialogTitle={{
+          label: 'Delete Task',
+          className: 'text-center border-b-[1px] border-secondary pb-3 mb-6',
+        }}
+        handleDelete={handleDeleteCategory}
+      >
+        <div>
+          <p className="text-center text-sm font-normal">
+            Are You sure you want to delete this category?
+            <div className="mt-2 text-lg">{category.name}</div>
+          </p>
+        </div>
+      </DeleteConfirmDialog>
+    </>
   );
 };
 

--- a/src/components/molecules/categoryIcon/CategoryIcon.tsx
+++ b/src/components/molecules/categoryIcon/CategoryIcon.tsx
@@ -1,24 +1,30 @@
 import { Category } from '@/types/task/task.type';
 import Image from 'next/image';
 import React from 'react';
+import CancleIcon from '@/images/icons/cancle.svg';
 
 type CategoryIconProps = {
   category: Category;
   handleClickCategory: (category: Category) => void;
   selectedCategoryId: string;
+  isEditMode: boolean;
 };
 const CategoryIcon = ({
   category,
   handleClickCategory,
   selectedCategoryId,
+  isEditMode,
 }: CategoryIconProps) => {
   return (
     <button type="button" onClick={() => handleClickCategory(category)}>
       <div
-        className={`mx-auto h-16 w-16 basis-1/4 rounded-md ${category.color} ${
-          category._id === selectedCategoryId ? `border-[3px] border-primary` : ''
-        }`}
+        className={`relative mx-auto h-16 w-16 basis-1/4 rounded-md ${category.color} 
+          ${category._id === selectedCategoryId ? 'border-[3px] border-primary' : ''}
+          ${isEditMode ? ' border-[3px] border-dashed border-primary' : ''}
+        `}
       >
+        {isEditMode && <CancleIcon className="absolute right-[-7px] top-[-7px]" />}
+
         <div className="flex h-full items-center justify-center p-1.5">
           <div className="flex-none">
             <Image src={category.icon} alt="icon" width={42} height={42} />

--- a/src/components/molecules/taskDetail/TaskDetailHeader.tsx
+++ b/src/components/molecules/taskDetail/TaskDetailHeader.tsx
@@ -11,20 +11,20 @@ const TaskDetailHeader = () => {
   return (
     <div className="flex justify-between">
       <div className="flex-none">
-        <Button
-          className="flex h-8 w-8 items-center justify-center rounded-[4px] border border-[#1d1d1d] bg-[#1D1D1D]"
+        <button
+          className="flex h-8 w-8 items-center justify-center rounded-[4px] border border-dark bg-dark"
           onClick={handleGoBackPage}
         >
           <Image className="h-6 w-6" src={cancleIcon} alt="cancleIcon" />
-        </Button>
+        </button>
       </div>
       <div className="flex-none">
-        <Button
-          className="flex h-8 w-8 items-center justify-center rounded-[4px] border border-[#1d1d1d] bg-[#1D1D1D]"
+        <button
+          className="flex h-8 w-8 items-center justify-center rounded-[4px] border border-dark bg-dark"
           onClick={handleTaskInfoReflash}
         >
           <Image className="h-6 w-6" src={repeatIcon} alt="repeatIcon" />
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/src/components/organisms/taskDetail/DeleteConfirmDialog.tsx
+++ b/src/components/organisms/taskDetail/DeleteConfirmDialog.tsx
@@ -10,24 +10,20 @@ type DeleteConfirmDialogProps = {
     label: string;
     className: string;
   };
-  taskTitle: string;
+  children: React.ReactNode;
+  handleDelete: () => void;
 };
 
 const DeleteConfirmDialog = ({
   isShowModal,
   close,
   dialogTitle,
-  taskTitle,
+  children,
+  handleDelete,
 }: DeleteConfirmDialogProps) => {
   return (
     <Dialog isShowModal={isShowModal} close={close} title={dialogTitle}>
-      <div>
-        <p className="text-center text-lg font-normal">
-          Are You sure you want to delete this task?
-          <br />
-          Task title : {taskTitle}
-        </p>
-      </div>
+      {children}
       <div className="mt-5 flex">
         <div className="basis-1/2">
           <Button variant="text" className="w-full" onClick={close}>
@@ -35,7 +31,11 @@ const DeleteConfirmDialog = ({
           </Button>
         </div>
         <div className="basis-1/2">
-          <Button className="w-full rounded-md" variant="contained" onClick={close}>
+          <Button
+            className="w-full rounded-md"
+            variant="contained"
+            onClick={handleDelete}
+          >
             Delete
           </Button>
         </div>

--- a/src/components/organisms/taskDetail/TaskDetailInfo.hook.tsx
+++ b/src/components/organisms/taskDetail/TaskDetailInfo.hook.tsx
@@ -25,7 +25,7 @@ const useTaskDetailInfo = (_task: Task) => {
   // task 삭제 후 메인 페이지로 이동
   const handleTaskDelete = async () => {
     setIsShowCloseModal(true);
-    const isDelete = await mutation.mutateAsync(taskId);
+    await mutation.mutateAsync(taskId);
   };
   const {
     setTaskFormStep,

--- a/src/components/organisms/taskDetail/TaskDetailInfo.tsx
+++ b/src/components/organisms/taskDetail/TaskDetailInfo.tsx
@@ -30,6 +30,7 @@ const TaskDetailInfo = ({ task }: TaskDetailInfoProps) => {
     setIsShowCloseModal,
     editTask,
     handleSubmitTaskEdit,
+    handleTaskDelete,
   } = useTaskDetailInfo(task);
 
   return (
@@ -111,8 +112,16 @@ const TaskDetailInfo = ({ task }: TaskDetailInfoProps) => {
             label: 'Delete Task',
             className: 'text-center border-b-[1px] border-secondary pb-3 mb-6',
           }}
-          taskTitle={editTask.title}
-        />
+          handleDelete={handleTaskDelete}
+        >
+          <div>
+            <p className="text-center text-lg font-normal">
+              Are You sure you want to delete this task?
+              <br />
+              Task title : {editTask.title}
+            </p>
+          </div>
+        </DeleteConfirmDialog>
       </div>
 
       {/* edit buttn */}

--- a/src/components/organisms/teskDialog/CategoryCreateForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategoryCreateForm.hook.tsx
@@ -24,25 +24,34 @@ const useCategoryCreateForm = (
   const { selectedCategory, isCategoryEditMode } = taskStore((state) => state);
   const [categoryPreview, setCategoryPreview] = useState<CategoryAdd>(defaultCategory);
 
+  const { register, handleSubmit, setValue, watch, reset } = useForm({
+    resolver: yupResolver(categoryAddSchema),
+  });
+
+  // store에서 선택된 카테고리에 따라 폼, 미리보기를 설정.
+  useEffect(() => {
+    const category = isCategoryEditMode ? selectedCategory : defaultCategory;
+    reset(category);
+    setCategoryPreview(category);
+  }, [selectedCategory]);
+
+  // 색 선택 시 form와 미리보기 state의 color를 같이 설정한다.
   const handleSetColor = (color: string) => {
     setValue('color', color);
     setCategoryPreview((prev) => ({ ...prev, color }));
   };
 
-  const { register, handleSubmit, setValue, watch, reset } = useForm({
-    resolver: yupResolver(categoryAddSchema),
-  });
-
-  useEffect(() => {
-    reset(isCategoryEditMode ? selectedCategory : defaultCategory);
-    setCategoryPreview(isCategoryEditMode ? selectedCategory : defaultCategory);
-  }, [selectedCategory]);
-
+  // 카테고리 이름변경 시 미리보기 이름 변경
   const categoryName = watch(['name'])[0];
-
   useEffect(() => {
     setCategoryPreview((prev) => ({ ...prev, name: categoryName }));
   }, [categoryName]);
+
+  // 이모지 선택 시 form, 미리보기 설정
+  const handleClickEmoji = (emoji: EmojiClickData) => {
+    setCategoryPreview((prev) => ({ ...prev, icon: emoji.imageUrl }));
+    setValue('icon', emoji.imageUrl);
+  };
 
   const handleSubmitError = (e: FieldErrors<CategoryAdd>) => {
     for (const [key, value] of Object.entries(e)) {
@@ -81,11 +90,6 @@ const useCategoryCreateForm = (
           name: category.name,
         },
       });
-  };
-
-  const handleClickEmoji = (emoji: EmojiClickData) => {
-    setCategoryPreview((prev) => ({ ...prev, icon: emoji.imageUrl }));
-    setValue('icon', emoji.imageUrl);
   };
 
   return {

--- a/src/components/organisms/teskDialog/CategoryCreateForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategoryCreateForm.hook.tsx
@@ -1,7 +1,13 @@
 import { useClientTranslation } from '@/libs/i18n/useClientTranslation';
 import { rqKey } from '@/libs/react-query';
-import { postCategory } from '@/services/category';
-import { CategoryAdd, TASK_FORM_STEP, categoryAddSchema } from '@/types/task/task.type';
+import { taskStore } from '@/libs/zustand';
+import { postCategory, putCategory } from '@/services/category';
+import {
+  Category,
+  CategoryAdd,
+  TASK_FORM_STEP,
+  categoryAddSchema,
+} from '@/types/task/task.type';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EmojiClickData } from 'emoji-picker-react';
@@ -12,33 +18,31 @@ import { toast } from 'react-toastify';
 const useCategoryCreateForm = (
   handleSetTaskFormStep: (taskFormStep: TASK_FORM_STEP) => void,
 ) => {
+  const defaultCategory = { color: '', icon: '', name: '' };
   const { t } = useClientTranslation('taskDialog');
   const queryClient = useQueryClient();
-  const [categoryPreview, setCategoryPreview] = useState<CategoryAdd>({
-    color: '',
-    icon: '',
-    name: '',
-  });
+  const { selectedCategory, isCategoryEditMode } = taskStore((state) => state);
+  const [categoryPreview, setCategoryPreview] = useState<CategoryAdd>(defaultCategory);
 
   const handleSetColor = (color: string) => {
     setValue('color', color);
     setCategoryPreview((prev) => ({ ...prev, color }));
   };
 
-  const { register, handleSubmit, setValue, watch } = useForm({
-    defaultValues: {
-      name: '',
-      color: '',
-      icon: '',
-    },
+  const { register, handleSubmit, setValue, watch, reset } = useForm({
     resolver: yupResolver(categoryAddSchema),
   });
 
-  const watchName = watch(['name'])[0];
+  useEffect(() => {
+    reset(isCategoryEditMode ? selectedCategory : defaultCategory);
+    setCategoryPreview(isCategoryEditMode ? selectedCategory : defaultCategory);
+  }, [selectedCategory]);
+
+  const categoryName = watch(['name'])[0];
 
   useEffect(() => {
-    setCategoryPreview((prev) => ({ ...prev, name: watchName }));
-  }, [watchName]);
+    setCategoryPreview((prev) => ({ ...prev, name: categoryName }));
+  }, [categoryName]);
 
   const handleSubmitError = (e: FieldErrors<CategoryAdd>) => {
     for (const [key, value] of Object.entries(e)) {
@@ -47,7 +51,7 @@ const useCategoryCreateForm = (
     }
   };
 
-  const mutation = useMutation({
+  const insertMutation = useMutation({
     mutationFn: postCategory,
     onSuccess: ({ data }) => {
       toast.success(t('category_create.add_category', { categoryName: data.name }));
@@ -56,8 +60,27 @@ const useCategoryCreateForm = (
     },
   });
 
-  const handleSubmitSuccess = (newCategory: CategoryAdd) => {
-    mutation.mutate(newCategory);
+  const updateMutation = useMutation({
+    mutationFn: putCategory,
+    onSuccess: ({ data }) => {
+      // FIXME:
+      toast.success(t('category_create.add_category', { categoryName: data.name }));
+      handleSetTaskFormStep(TASK_FORM_STEP.CATEGORY);
+      queryClient.invalidateQueries({ queryKey: [rqKey.categories] });
+    },
+  });
+
+  const handleSubmitSuccess = (category: CategoryAdd | Category) => {
+    if (!isCategoryEditMode) insertMutation.mutate(category);
+    else
+      updateMutation.mutate({
+        categoryId: (category as Category)._id,
+        category: {
+          color: category.color,
+          icon: category.icon,
+          name: category.name,
+        },
+      });
   };
 
   const handleClickEmoji = (emoji: EmojiClickData) => {
@@ -74,6 +97,7 @@ const useCategoryCreateForm = (
     handleSubmit,
     handleSubmitSuccess,
     handleSubmitError,
+    isCategoryEditMode,
   };
 };
 

--- a/src/components/organisms/teskDialog/CategoryCreateForm.tsx
+++ b/src/components/organisms/teskDialog/CategoryCreateForm.tsx
@@ -18,6 +18,7 @@ const CategoryCreateForm = ({ handleSetTaskFormStep }: CategoryCreateFormProps) 
     handleSubmit,
     handleSubmitSuccess,
     handleSubmitError,
+    isCategoryEditMode,
   } = useCategoryCreateForm(handleSetTaskFormStep);
 
   return (
@@ -109,7 +110,7 @@ const CategoryCreateForm = ({ handleSetTaskFormStep }: CategoryCreateFormProps) 
           </div>
           <div className="basis-1/2">
             <Button className="w-full rounded-md" variant="contained" type="submit">
-              {t('button.save')}
+              {!isCategoryEditMode ? t('button.save') : 'Edit'}
             </Button>
           </div>
         </div>

--- a/src/components/organisms/teskDialog/CategoryCreateForm.tsx
+++ b/src/components/organisms/teskDialog/CategoryCreateForm.tsx
@@ -78,10 +78,6 @@ const CategoryCreateForm = ({ handleSetTaskFormStep }: CategoryCreateFormProps) 
                   category: Categories.ANIMALS_NATURE,
                   name: 'Animals & Nature',
                 },
-                /*   {
-                  category: Categories.SMILEYS_PEOPLE,
-                  name: 'Smileys & People',
-                }, */
                 {
                   category: Categories.TRAVEL_PLACES,
                   name: 'Travel & Places',

--- a/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
@@ -4,7 +4,7 @@ import { taskStore } from '@/libs/zustand';
 import { getCategories } from '@/services/category';
 import { AddTask, Category, TASK_FORM_STEP, Task } from '@/types/task/task.type';
 import { useQuery } from '@tanstack/react-query';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { toast } from 'react-toastify';
 
 export const useCategorySelectForm = (
@@ -14,21 +14,25 @@ export const useCategorySelectForm = (
   isEditMode: boolean,
 ) => {
   const { t } = useClientTranslation('taskDialog');
-  const [selectedCategory, setSelectedCategory] = useState<Category>({
-    _id: categoryId,
-    color: '',
-    icon: '',
-    name: '',
-  });
 
   const { data, isLoading } = useQuery({
     queryFn: getCategories,
     queryKey: [rqKey.categories],
   });
 
+  const {
+    isCategoryEditMode,
+    setIsCategoryEditMode,
+    selectedCategory,
+    setSelectedCategory,
+  } = taskStore((state) => state);
+
   const categories = useMemo(() => data?.data, [data?.data]);
   const handleClickCategory = (category: Category) => {
     setSelectedCategory(category);
+    if (isCategoryEditMode) {
+      handleSetTaskFormStep(TASK_FORM_STEP.CREATE_CATEGORY);
+    }
   };
 
   /**
@@ -52,13 +56,18 @@ export const useCategorySelectForm = (
   const handleCancel = () => {
     setIsCategoryEditMode(false);
     handleSetTaskFormStep(TASK_FORM_STEP.MAIN);
+    setSelectedCategory({
+      _id: '',
+      color: '',
+      icon: '',
+      name: '',
+    });
   };
 
   const handleCreateCategory = () => {
     handleSetTaskFormStep(TASK_FORM_STEP.CREATE_CATEGORY);
   };
 
-  const { isCategoryEditMode, setIsCategoryEditMode } = taskStore((state) => state);
   const handleToggleCategoryEditMode = () => {
     setIsCategoryEditMode(!isCategoryEditMode);
   };

--- a/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
@@ -68,10 +68,6 @@ export const useCategorySelectForm = (
     handleSetTaskFormStep(TASK_FORM_STEP.CREATE_CATEGORY);
   };
 
-  const handleToggleCategoryEditMode = () => {
-    setIsCategoryEditMode(!isCategoryEditMode);
-  };
-
   return {
     t,
     isLoading,
@@ -81,7 +77,6 @@ export const useCategorySelectForm = (
     handleSaveCategory,
     handleCreateCategory,
     isCategoryEditMode,
-    handleToggleCategoryEditMode,
     handleCancel,
   };
 };

--- a/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
@@ -1,5 +1,6 @@
 import { useClientTranslation } from '@/libs/i18n/useClientTranslation';
 import { rqKey } from '@/libs/react-query';
+import { taskStore } from '@/libs/zustand';
 import { getCategories } from '@/services/category';
 import { AddTask, Category, TASK_FORM_STEP, Task } from '@/types/task/task.type';
 import { useQuery } from '@tanstack/react-query';
@@ -47,8 +48,19 @@ export const useCategorySelectForm = (
     handleSetTaskFormStep(TASK_FORM_STEP.MAIN);
   };
 
+  // 모달을 닫을 경우 수정모드를 false로 초기화 한다.
+  const handleCancel = () => {
+    setIsCategoryEditMode(false);
+    handleSetTaskFormStep(TASK_FORM_STEP.MAIN);
+  };
+
   const handleCreateCategory = () => {
     handleSetTaskFormStep(TASK_FORM_STEP.CREATE_CATEGORY);
+  };
+
+  const { isCategoryEditMode, setIsCategoryEditMode } = taskStore((state) => state);
+  const handleToggleCategoryEditMode = () => {
+    setIsCategoryEditMode(!isCategoryEditMode);
   };
 
   return {
@@ -59,5 +71,8 @@ export const useCategorySelectForm = (
     selectedCategory,
     handleSaveCategory,
     handleCreateCategory,
+    isCategoryEditMode,
+    handleToggleCategoryEditMode,
+    handleCancel,
   };
 };

--- a/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.hook.tsx
@@ -28,6 +28,7 @@ export const useCategorySelectForm = (
   } = taskStore((state) => state);
 
   const categories = useMemo(() => data?.data, [data?.data]);
+  // 카테고리를 선택 시 카테고리 수정모드이면 카테고리 생성/수정 폼을 표시한다.
   const handleClickCategory = (category: Category) => {
     setSelectedCategory(category);
     if (isCategoryEditMode) {
@@ -37,7 +38,7 @@ export const useCategorySelectForm = (
 
   /**
    * 카테고리 선택 유효성 체크 후 form에 value 설정
-   * 수정: 다이얼로그에서 이미지를 함께 보여줘야 하므로 카테고리 객체 자체를 설정
+   * 카테고리 재 선택: 다이얼로그에서 이미지를 함께 보여줘야 하므로 카테고리 객체 자체를 설정
    * 추가: 선택한 카테고리 아이디만 객체에 설정
    */
   const handleSaveCategory = () => {

--- a/src/components/organisms/teskDialog/CategorySelectForm.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.tsx
@@ -21,7 +21,6 @@ const CategorySelectForm = ({
     handleSaveCategory,
     handleCreateCategory,
     isCategoryEditMode,
-    handleToggleCategoryEditMode,
     handleCancel,
   } = useCategorySelectForm(
     categoryId,
@@ -33,17 +32,6 @@ const CategorySelectForm = ({
   return (
     <div className="flex flex-col">
       <div className="flex-auto">
-        {!isLoading && (
-          <div className="mt-2 text-right">
-            <Button
-              variant="outlined"
-              className="h-auto px-1 py-0 text-sm font-light"
-              onClick={handleToggleCategoryEditMode}
-            >
-              {isCategoryEditMode ? 'Cancel' : 'Edit'}
-            </Button>
-          </div>
-        )}
         <div className="my-5 grid grid-cols-4 items-center justify-center gap-y-4 text-center">
           {isLoading ? (
             <CategoryIconSkeleton />

--- a/src/components/organisms/teskDialog/CategorySelectForm.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.tsx
@@ -1,5 +1,4 @@
-import React, { useRef } from 'react';
-import { TASK_FORM_STEP } from '@/types/task/task.type';
+import React from 'react';
 import Button from '@/components/atoms/button/Button';
 import { useCategorySelectForm } from './CategorySelectForm.hook';
 import { CategorySelectFormProps } from './taskDialog.types';
@@ -21,6 +20,9 @@ const CategorySelectForm = ({
     selectedCategory,
     handleSaveCategory,
     handleCreateCategory,
+    isCategoryEditMode,
+    handleToggleCategoryEditMode,
+    handleCancel,
   } = useCategorySelectForm(
     categoryId,
     handleSetFormValue,
@@ -30,8 +32,19 @@ const CategorySelectForm = ({
 
   return (
     <div className="flex flex-col">
-      <div className="my-5 flex-auto">
-        <div className="grid grid-cols-4 items-center justify-center gap-y-4 text-center">
+      <div className="flex-auto">
+        {!isLoading && (
+          <div className="mt-2 text-right">
+            <Button
+              variant="contained"
+              className="h-auto px-1 py-0 font-normal"
+              onClick={handleToggleCategoryEditMode}
+            >
+              {isCategoryEditMode ? 'Cancel' : 'Edit'}
+            </Button>
+          </div>
+        )}
+        <div className="my-5 grid grid-cols-4 items-center justify-center gap-y-4 text-center">
           {isLoading ? (
             <CategoryIconSkeleton />
           ) : (
@@ -42,33 +55,32 @@ const CategorySelectForm = ({
                   handleClickCategory={handleClickCategory}
                   category={category}
                   selectedCategoryId={selectedCategory._id}
+                  isEditMode={isCategoryEditMode}
                 />
               ))}
 
               {/* category add button*/}
-              <button onClick={() => handleCreateCategory()} type="button">
-                <div
-                  className={`mx-auto h-16 w-16 basis-1/4 rounded-md border-[3px] border-white/25`}
-                >
-                  <div className="flex h-full items-center justify-center p-1.5">
-                    <div className="flex-none text-2xl">
-                      <AddIcon />
+              {isCategoryEditMode && (
+                <button onClick={handleCreateCategory} type="button">
+                  <div
+                    className={`mx-auto h-16 w-16 basis-1/4 rounded-md border-[3px] border-white/25`}
+                  >
+                    <div className="flex h-full items-center justify-center p-1.5">
+                      <div className="flex-none text-2xl">
+                        <AddIcon />
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div className="mt-2 text-sm">{t('button.create_new')}</div>
-              </button>
+                  <div className="mt-2 text-sm">{t('button.create_new')}</div>
+                </button>
+              )}
             </>
           )}
         </div>
       </div>
       <div className="flex">
         <div className="basis-1/2">
-          <Button
-            variant="text"
-            className="w-full"
-            onClick={() => handleSetTaskFormStep(TASK_FORM_STEP.MAIN)}
-          >
+          <Button variant="text" className="w-full" onClick={handleCancel}>
             {t('button.cancel')}
           </Button>
         </div>
@@ -77,6 +89,7 @@ const CategorySelectForm = ({
             className="w-full rounded-md"
             variant="contained"
             onClick={handleSaveCategory}
+            disabled={isCategoryEditMode}
           >
             {t('button.save')}
           </Button>

--- a/src/components/organisms/teskDialog/CategorySelectForm.tsx
+++ b/src/components/organisms/teskDialog/CategorySelectForm.tsx
@@ -36,8 +36,8 @@ const CategorySelectForm = ({
         {!isLoading && (
           <div className="mt-2 text-right">
             <Button
-              variant="contained"
-              className="h-auto px-1 py-0 font-normal"
+              variant="outlined"
+              className="h-auto px-1 py-0 text-sm font-light"
               onClick={handleToggleCategoryEditMode}
             >
               {isCategoryEditMode ? 'Cancel' : 'Edit'}
@@ -60,7 +60,7 @@ const CategorySelectForm = ({
               ))}
 
               {/* category add button*/}
-              {isCategoryEditMode && (
+              {!isCategoryEditMode && (
                 <button onClick={handleCreateCategory} type="button">
                   <div
                     className={`mx-auto h-16 w-16 basis-1/4 rounded-md border-[3px] border-white/25`}

--- a/src/components/organisms/teskDialog/TaskDialog.hook.tsx
+++ b/src/components/organisms/teskDialog/TaskDialog.hook.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postTask } from '@/services/task';
 import { rqKey } from '@/libs/react-query';
 import { taskStore } from '@/libs/zustand';
+import Button from '@/components/atoms/button/Button';
 
 export const useTaskDialog = (isNewTask: boolean) => {
   const { t } = useClientTranslation('taskDialog');
@@ -28,6 +29,7 @@ export const useTaskDialog = (isNewTask: boolean) => {
     setTask,
     setTaskFormStep,
     isCategoryEditMode,
+    setIsCategoryEditMode,
   } = taskStore((state) => state);
 
   const queryClient = useQueryClient();
@@ -103,7 +105,7 @@ export const useTaskDialog = (isNewTask: boolean) => {
         break;
       }
       case TASK_FORM_STEP.CATEGORY: {
-        title.label = t('category_select.title');
+        // title.label = t('category_select.title');
         break;
       }
       case TASK_FORM_STEP.CREATE_CATEGORY: {
@@ -117,6 +119,24 @@ export const useTaskDialog = (isNewTask: boolean) => {
     }
     return title;
   }, [taskFormStep, isEditMode]);
+
+  const CategoryTitle = (
+    <div className="mb-2 border-b-[1px] border-secondary pb-2 text-center text-lg font-bold leading-normal">
+      <div className="relative">
+        {isCategoryEditMode ? 'Category edit' : t('category_create.title')}
+
+        <div className="absolute right-0 top-0">
+          <Button
+            variant="outlined"
+            className="h-auto px-1 py-0 text-sm font-light"
+            onClick={() => setIsCategoryEditMode(!isCategoryEditMode)}
+          >
+            {isCategoryEditMode ? 'Cancel' : 'Edit'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 
   /**
    * 수정 다이얼로그에서 save버튼을 눌렀을 경우 메인이 아닌 다이얼로그를 닫음.
@@ -154,5 +174,6 @@ export const useTaskDialog = (isNewTask: boolean) => {
     handleCloseModal,
     isEditMode,
     setIsShowModal,
+    CategoryTitle,
   };
 };

--- a/src/components/organisms/teskDialog/TaskDialog.hook.tsx
+++ b/src/components/organisms/teskDialog/TaskDialog.hook.tsx
@@ -79,7 +79,7 @@ export const useTaskDialog = (isNewTask: boolean) => {
     resolver: yupResolver(isNewTask ? addTaskSchema : taskSchema),
   });
 
-  // 수정 - 의 경우 전받은 task 데이터를 기준으로 초기화
+  // 수정 - 전달받은 task 데이터를 기준으로 초기화
   // 입력 - 기본 빈값으로 초기화
   useEffect(() => {
     if (isEditMode) {
@@ -89,6 +89,8 @@ export const useTaskDialog = (isNewTask: boolean) => {
     }
   }, [task, isEditMode]);
 
+  // 각 폼 타입에 따른 타이틀 설정.
+  // 카테고리의 경우 버툰으 추가로 표시되어야 하므로 TitleCompont props를 전달하여 사용한다.
   const dialogTitle = useCallback(() => {
     let title = {
       label: '',
@@ -105,7 +107,6 @@ export const useTaskDialog = (isNewTask: boolean) => {
         break;
       }
       case TASK_FORM_STEP.CATEGORY: {
-        // title.label = t('category_select.title');
         break;
       }
       case TASK_FORM_STEP.CREATE_CATEGORY: {
@@ -120,6 +121,7 @@ export const useTaskDialog = (isNewTask: boolean) => {
     return title;
   }, [taskFormStep, isEditMode]);
 
+  // 카테고리 타이틀 컴포넌트
   const CategoryTitle = (
     <div className="mb-2 border-b-[1px] border-secondary pb-2 text-center text-lg font-bold leading-normal">
       <div className="relative">
@@ -139,7 +141,7 @@ export const useTaskDialog = (isNewTask: boolean) => {
   );
 
   /**
-   * 수정 다이얼로그에서 save버튼을 눌렀을 경우 메인이 아닌 다이얼로그를 닫음.
+   * 수정 다이얼로그에서 save버튼을 눌렀을 경우 메인 폼으로 이동이 아닌 다이얼로그를 닫음.
    * 설정한 form 데이터 store에 설정
    */
   const handleSetTaskFormStep = useCallback(

--- a/src/components/organisms/teskDialog/TaskDialog.hook.tsx
+++ b/src/components/organisms/teskDialog/TaskDialog.hook.tsx
@@ -27,6 +27,7 @@ export const useTaskDialog = (isNewTask: boolean) => {
     setIsShowModal,
     setTask,
     setTaskFormStep,
+    isCategoryEditMode,
   } = taskStore((state) => state);
 
   const queryClient = useQueryClient();
@@ -106,7 +107,7 @@ export const useTaskDialog = (isNewTask: boolean) => {
         break;
       }
       case TASK_FORM_STEP.CREATE_CATEGORY: {
-        title.label = t('category_create.title');
+        title.label = isCategoryEditMode ? 'Category edit' : t('category_create.title');
         break;
       }
       case TASK_FORM_STEP.PRIORITY: {

--- a/src/components/organisms/teskDialog/TaskDialog.tsx
+++ b/src/components/organisms/teskDialog/TaskDialog.tsx
@@ -25,11 +25,19 @@ const TaskDialog = ({ dictionary, isNewTask = false }: TaskDialogProps) => {
     handleCloseModal,
     isEditMode,
     setIsShowModal,
+    CategoryTitle,
   } = useTaskDialog(isNewTask);
 
   return (
     isShowModal && (
-      <Dialog isShowModal={isShowModal} close={handleCloseModal} title={dialogTitle()}>
+      <Dialog
+        isShowModal={isShowModal}
+        close={handleCloseModal}
+        title={taskFormStep !== TASK_FORM_STEP.CATEGORY ? dialogTitle() : undefined}
+        TitleComonent={
+          taskFormStep === TASK_FORM_STEP.CATEGORY ? CategoryTitle : undefined
+        }
+      >
         <form onSubmit={handleSubmit(onSuccess, onSubmitError)}>
           {taskFormStep === TASK_FORM_STEP.MAIN && (
             <TaskMainForm

--- a/src/libs/zustand/slices/taskSlice.ts
+++ b/src/libs/zustand/slices/taskSlice.ts
@@ -8,6 +8,7 @@ type TaskState = {
   task: AddTask | Task;
   filter: TaskFilter;
   isEditMode: boolean;
+  isCategoryEditMode: boolean;
 };
 
 type TaskAction = {
@@ -16,6 +17,7 @@ type TaskAction = {
   setTask: (task: Partial<AddTask | Task>) => void;
   setFilter: (filter: Partial<TaskFilter>) => void;
   setIsEditMode: (isEditMode: boolean) => void;
+  setIsCategoryEditMode: (isCategoryEditMode: boolean) => void;
 };
 
 export const initialTaskState: TaskState = {
@@ -42,6 +44,7 @@ export const initialTaskState: TaskState = {
     },
   },
   isEditMode: false,
+  isCategoryEditMode: false,
 };
 
 export const createTaskSlice: StateCreator<TaskState & TaskAction, [], []> = (set) => ({
@@ -65,5 +68,9 @@ export const createTaskSlice: StateCreator<TaskState & TaskAction, [], []> = (se
   setIsEditMode: (isEditMode: boolean) =>
     set(() => ({
       isEditMode,
+    })),
+  setIsCategoryEditMode: (isCategoryEditMode: boolean) =>
+    set(() => ({
+      isCategoryEditMode,
     })),
 });

--- a/src/libs/zustand/slices/taskSlice.ts
+++ b/src/libs/zustand/slices/taskSlice.ts
@@ -1,4 +1,10 @@
-import { AddTask, TASK_FORM_STEP, Task, TaskFilter } from '@/types/task/task.type';
+import {
+  AddTask,
+  Category,
+  TASK_FORM_STEP,
+  Task,
+  TaskFilter,
+} from '@/types/task/task.type';
 import { format } from 'date-fns';
 import { StateCreator, create } from 'zustand';
 
@@ -9,6 +15,7 @@ type TaskState = {
   filter: TaskFilter;
   isEditMode: boolean;
   isCategoryEditMode: boolean;
+  selectedCategory: Category;
 };
 
 type TaskAction = {
@@ -18,6 +25,7 @@ type TaskAction = {
   setFilter: (filter: Partial<TaskFilter>) => void;
   setIsEditMode: (isEditMode: boolean) => void;
   setIsCategoryEditMode: (isCategoryEditMode: boolean) => void;
+  setSelectedCategory: (selectedCategory: Category) => void;
 };
 
 export const initialTaskState: TaskState = {
@@ -45,6 +53,12 @@ export const initialTaskState: TaskState = {
   },
   isEditMode: false,
   isCategoryEditMode: false,
+  selectedCategory: {
+    _id: '',
+    color: '',
+    icon: '',
+    name: '',
+  },
 };
 
 export const createTaskSlice: StateCreator<TaskState & TaskAction, [], []> = (set) => ({
@@ -72,5 +86,9 @@ export const createTaskSlice: StateCreator<TaskState & TaskAction, [], []> = (se
   setIsCategoryEditMode: (isCategoryEditMode: boolean) =>
     set(() => ({
       isCategoryEditMode,
+    })),
+  setSelectedCategory: (selectedCategory: Category) =>
+    set(() => ({
+      selectedCategory,
     })),
 });

--- a/src/services/category/index.ts
+++ b/src/services/category/index.ts
@@ -3,5 +3,14 @@ import { Category, CategoryAdd } from '@/types/task/task.type';
 
 export const postCategory = (newCategory: CategoryAdd) =>
   http.post<Category>('/api/category', newCategory);
+export const putCategory = ({
+  categoryId,
+  category,
+}: {
+  categoryId: string;
+  category: CategoryAdd;
+}) => http.put<Category>(`/api/category/${categoryId}`, category);
+export const deleteCategory = (categoryId: string) =>
+  http.delete<{ deletedCount: number }>(`/api/category/${categoryId}`);
 
 export const getCategories = () => http.get<Category[]>('/api/category');


### PR DESCRIPTION
### 버튼 컴포넌트 수정
 - `tw merge` 라이브러리를 사용하여 머지 적용
 - `variant`에 따른 swith문으로 클래스 설정

### Dialog 컴포넌트
 - TitleComponen컴포넌트 props추가
 - 해당 컴포넌트가 존재할 경우 해당 컴포넌틀 사용하여 타이틀 영역 표시

### DeleteConfirmDialog 공통 컴포넌트 화 
 - task와 카테고리의 삭제가 내용만 다르며 중요 프로세스는 동일하므로 children으로 내용 부분을 받게 처리하여 공통 컴포넌트화 
 - task 삭제 이벤트 오류 수정

### store isCategoryEditMode 추가
 - 카테고리 수정 여부를 체크하기 위한 값 추가

### 카테고리 수정/삭제
 - 카테고리 모달에서 수정 버튼을 눌러 수정 토글 설정
 - 수정 모드에서 각 카테고리의 x버튼 누를시 확인 모달 -> 삭제 처리
 - 수정 모두에서 카테고리 선택 시 수정 모달로 이동